### PR TITLE
Do nothing in acceleration mapping if there are zero blocks

### DIFF
--- a/vlasovsolver/cpu_acc_map.cpp
+++ b/vlasovsolver/cpu_acc_map.cpp
@@ -128,6 +128,11 @@ bool map_1d(SpatialCell* spatial_cell,
    vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh    = spatial_cell->get_velocity_mesh(popID);
    vmesh::VelocityBlockContainer<vmesh::LocalID>& blockContainer = spatial_cell->get_velocity_blocks(popID);
 
+   //nothing to do if no blocks
+   if(vmesh.size() == 0 )
+      return true;
+   
+
    // Velocity grid refinement level, has no effect but is 
    // needed in some vmesh::VelocityMesh function calls.
    const uint8_t REFLEVEL = 0;


### PR DESCRIPTION
This avoids a segmentation fault. The segmentation fault was because the sort into columns code created a valid output, with 1 set of columns, that had zero length, but that in turn was not properly handled in acceleration. This would only happen for empty velocity meshes, and this case is easier to handle here.

