### PR TITLE
Fix for acc timestep

### DIFF
--- a/vlasovsolver/vlasovmover.cpp
+++ b/vlasovsolver/vlasovmover.cpp
@@ -424,11 +424,15 @@ void calculateAcceleration(dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& 
        for (size_t c=0; c<cells.size(); ++c) {
           SpatialCell* SC = mpiGrid[cells[c]];
           const vmesh::VelocityMesh<vmesh::GlobalID,vmesh::LocalID>& vmesh = SC->get_velocity_mesh(popID);
-          // disregard boundary cells and do not propagate spatial 
-          // cells with no blocks (well, do not computes in practice)
-          if (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY && vmesh.size() != 0) {
-             propagatedCells.push_back(cells[c]);
-             //prepare for acceleration, updates max dt for each cell
+          // disregard boundary cells, in preparation for acceleration 
+          if (SC->sysBoundaryFlag == sysboundarytype::NOT_SYSBOUNDARY ) {
+             if(vmesh.size() != 0){
+                //do not propagate spatial cells with no blocks
+                propagatedCells.push_back(cells[c]);
+             }
+             //prepare for acceleration, updates max dt for each cell, it
+             //needs to be set to somthing sensible for _all_ cells, even if
+             //they are not propagated
              prepareAccelerateCell(SC, popID);
              //update max subcycles for all cells in this process
              maxSubcycles = max((int)getAccelerationSubcycles(SC, dt, popID), maxSubcycles);


### PR DESCRIPTION
We need to set some sensible value for maxvdt, done in prepareAccelerateCell.  Here we just init it as all other cells, one could potentially also set it to max-real.