### PR TITLE
Per face outflow resets, forward ported onto the multipop branch.

### DIFF
--- a/projects/Flowthrough/Flowthrough.cpp
+++ b/projects/Flowthrough/Flowthrough.cpp
@@ -114,31 +114,31 @@ namespace projects {
          const std::string& pop = getObjectWrapper().particleSpecies[i].name;
          FlowthroughSpeciesParameters sP;
 
-         if(!RP::get("Flowthrough.rho", sP.rho)) {
+         if(!RP::get(pop + "_Flowthrough.rho", sP.rho)) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }
-         if(!RP::get("Flowthrough.T", sP.T)) {
+         if(!RP::get(pop + "_Flowthrough.T", sP.T)) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }
-         if(!RP::get("Flowthrough.VX0", sP.V0[0])) {
+         if(!RP::get(pop + "_Flowthrough.VX0", sP.V0[0])) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }
-         if(!RP::get("Flowthrough.VY0", sP.V0[1])) {
+         if(!RP::get(pop + "_Flowthrough.VY0", sP.V0[1])) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }
-         if(!RP::get("Flowthrough.VZ0", sP.V0[2])) {
+         if(!RP::get(pop + "_Flowthrough.VZ0", sP.V0[2])) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }
-         if(!RP::get("Flowthrough.nSpaceSamples", sP.nSpaceSamples)) {
+         if(!RP::get(pop + "_Flowthrough.nSpaceSamples", sP.nSpaceSamples)) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }
-         if(!RP::get("Flowthrough.nVelocitySamples", sP.nVelocitySamples)) {
+         if(!RP::get(pop + "_Flowthrough.nVelocitySamples", sP.nVelocitySamples)) {
             if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
             exit(1);
          }

--- a/sysboundary/donotcompute.h
+++ b/sysboundary/donotcompute.h
@@ -69,7 +69,7 @@ namespace SBC {
          creal& dt,
          cuint& RKCase,
          cuint& component
-      ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticField called!" << std::endl;}
+      ) { std::cerr << "ERROR: DoNotCompute::fieldSolverBoundaryCondMagneticField called!" << std::endl; return 0.;}
       virtual void fieldSolverBoundaryCondElectricField(
          FsGrid< std::array<Real, fsgrids::efield::N_EFIELD>, 2> & EGrid,
          cint i,

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -57,6 +57,7 @@ namespace SBC {
       for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
         const std::string& pop = getObjectWrapper().particleSpecies[i].name;
 
+        Readparameters::addComposing(pop + "_outflow.reapplyFaceUponRestart", "List of faces on which outflow boundary conditions are to be reapplied upon restart ([xyz][+-]).");
         Readparameters::addComposing(pop + "_outflow.face", "List of faces on which outflow boundary conditions are to be applied ([xyz][+-]).");
         Readparameters::add(pop + "_outflow.vlasovScheme_face_x+", "Scheme to use on the face x+ (Copy, Limit, None)", defStr);
         Readparameters::add(pop + "_outflow.vlasovScheme_face_x-", "Scheme to use on the face x- (Copy, Limit, None)", defStr);
@@ -115,6 +116,10 @@ namespace SBC {
           if(face == "z-") { facesToProcess[5] = true; sP.facesToSkipVlasov[5] = false; }
         }
 
+        if(!Readparameters::get(pop + "_outflow.reapplyFaceUponRestart", sP.faceToReapplyUponRestartList)) {
+           if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
+           exit(1);
+        }
         std::array<std::string, 6> vlasovSysBoundarySchemeName;
         if(!Readparameters::get(pop + "_outflow.vlasovScheme_face_x+", vlasovSysBoundarySchemeName[0])) {
            if(myRank == MASTER_RANK) cerr << __FILE__ << ":" << __LINE__ << " ERROR: This option has not been added for population " << pop << "!" << endl;
@@ -191,6 +196,20 @@ namespace SBC {
          if(*it == "z+") facesToSkipFields[4] = true;
          if(*it == "z-") facesToSkipFields[5] = true;
       }
+
+      for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
+         const OutflowSpeciesParameters& sP = this->speciesParams[i];
+         for (it = faceToReapplyUponRestartList.begin();
+              it != faceToReapplyUponRestartList.end();
+         it++) {
+            if(*it == "x+") sP.facesToReapply[0] = true;
+            if(*it == "x-") sP.facesToReapply[1] = true;
+            if(*it == "y+") sP.facesToReapply[2] = true;
+            if(*it == "y-") sP.facesToReapply[3] = true;
+            if(*it == "z+") sP.facesToReapply[4] = true;
+            if(*it == "z-") sP.facesToReapply[5] = true;
+         }
+      }
       return true;
    }
    
@@ -229,17 +248,52 @@ namespace SBC {
          SpatialCell* cell = mpiGrid[cells[i]];
          if (cell->sysBoundaryFlag != this->getIndex()) continue;
          
-         // Defined in project.cpp, used here as the outflow cell has the same state 
-         // as the initial state of non-system boundary cells.
-         project.setCell(cell);
-         // WARNING Time-independence assumed here.
-         cell->parameters[CellParams::RHOM_DT2] = cell->parameters[CellParams::RHOM];
-         cell->parameters[CellParams::VX_DT2] = cell->parameters[CellParams::VX];
-         cell->parameters[CellParams::VY_DT2] = cell->parameters[CellParams::VY];
-         cell->parameters[CellParams::VZ_DT2] = cell->parameters[CellParams::VZ];
-         cell->parameters[CellParams::RHOQ_DT2] = cell->parameters[CellParams::RHOQ];
-      }
+      //   // Defined in project.cpp, used here as the outflow cell has the same state 
+      //   // as the initial state of non-system boundary cells.
+      //   project.setCell(cell);
+      //   // WARNING Time-independence assumed here.
+      //   cell->parameters[CellParams::RHOM_DT2] = cell->parameters[CellParams::RHOM];
+      //   cell->parameters[CellParams::VX_DT2] = cell->parameters[CellParams::VX];
+      //   cell->parameters[CellParams::VY_DT2] = cell->parameters[CellParams::VY];
+      //   cell->parameters[CellParams::VZ_DT2] = cell->parameters[CellParams::VZ];
+      //   cell->parameters[CellParams::RHOQ_DT2] = cell->parameters[CellParams::RHOQ];
+      //}
+         bool doApply = true;
+         
+         if(Parameters::isRestart) {
+            creal* const cellParams = &(mpiGrid[cells[i]]->parameters[0]);
+            creal dx = cellParams[CellParams::DX];
+            creal dy = cellParams[CellParams::DY];
+            creal dz = cellParams[CellParams::DZ];
+            creal x = cellParams[CellParams::XCRD] + 0.5*dx;
+            creal y = cellParams[CellParams::YCRD] + 0.5*dy;
+            creal z = cellParams[CellParams::ZCRD] + 0.5*dz;
+            
+            bool isThisCellOnAFace[6];
+            determineFace(&isThisCellOnAFace[0], x, y, z, dx, dy, dz);
+            
+            doApply=false;
+            // Comparison of the array defining which faces to use and the array telling on which faces this cell is
+            // TODO: Loop over populations
+            for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
+               const OutflowSpeciesParameters& sP = this->speciesParams[i];
+               for(uint j=0; j<6; j++) {
+                  doApply = doApply || (sP.facesToReapply[j] && isThisCellOnAFace[j]);
+               }
+            }
+         }
 
+         if(doApply) {
+            // Defined in project.cpp, used here as the outflow cell has the same state 
+            // as the initial state of non-system boundary cells.
+            project.setCell(cell);
+            // WARNING Time-independence assumed here.
+            cell->parameters[CellParams::RHO_DT2] = cell->parameters[CellParams::RHO];
+            cell->parameters[CellParams::RHOVX_DT2] = cell->parameters[CellParams::RHOVX];
+            cell->parameters[CellParams::RHOVY_DT2] = cell->parameters[CellParams::RHOVY];
+            cell->parameters[CellParams::RHOVZ_DT2] = cell->parameters[CellParams::RHOVZ];
+         }
+      }
       return true;
    }
 

--- a/sysboundary/outflow.cpp
+++ b/sysboundary/outflow.cpp
@@ -203,12 +203,12 @@ namespace SBC {
          for (it = sP.faceToReapplyUponRestartList.begin();
               it != sP.faceToReapplyUponRestartList.end();
          it++) {
-            if(*it == "x+") sP.facesToReapply[0] = true;
-            if(*it == "x-") sP.facesToReapply[1] = true;
-            if(*it == "y+") sP.facesToReapply[2] = true;
-            if(*it == "y-") sP.facesToReapply[3] = true;
-            if(*it == "z+") sP.facesToReapply[4] = true;
-            if(*it == "z-") sP.facesToReapply[5] = true;
+            if(*it == "x+") facesToReapply[0] = true;
+            if(*it == "x-") facesToReapply[1] = true;
+            if(*it == "y+") facesToReapply[2] = true;
+            if(*it == "y-") facesToReapply[3] = true;
+            if(*it == "z+") facesToReapply[4] = true;
+            if(*it == "z-") facesToReapply[5] = true;
          }
       }
       return true;
@@ -266,9 +266,8 @@ namespace SBC {
             doApply=false;
             // Comparison of the array defining which faces to use and the array telling on which faces this cell is
             for(uint i=0; i< getObjectWrapper().particleSpecies.size(); i++) {
-               const OutflowSpeciesParameters& sP = this->speciesParams[i];
                for(uint j=0; j<6; j++) {
-                  doApply = doApply || (sP.facesToReapply[j] && isThisCellOnAFace[j]);
+                  doApply = doApply || (facesToReapply[j] && isThisCellOnAFace[j]);
                }
             }
          }

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -38,8 +38,6 @@ namespace SBC {
       std::array<uint, 6> faceVlasovScheme;
       /*! List of faces on which outflow boundary conditions are to be reapplied upon restart ([xyz][+-]). */
       std::vector<std::string> faceToReapplyUponRestartList;
-      /*! Array of bool telling which faces are going to be reapplied upon restart.*/
-      bool facesToReapply[6];
 
       /*! Factor by which to quench the inflowing parts of the velocity distribution function.*/
       Real quenchFactor;

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -36,6 +36,10 @@ namespace SBC {
 			std::array<bool, 6> facesToSkipVlasov;
       /*! List of schemes to use for the Vlasov outflow boundary conditions on each face ([xyz][+-]). */
       std::array<uint, 6> faceVlasovScheme;
+      /*! List of faces on which outflow boundary conditions are to be reapplied upon restart ([xyz][+-]). */
+      std::vector<std::string> faceToReapplyUponRestartList;
+      /*! Array of bool telling which faces are going to be reapplied upon restart.*/
+      bool facesToReapply[6];
 
       /*! Factor by which to quench the inflowing parts of the velocity distribution function.*/
       Real quenchFactor;
@@ -136,6 +140,14 @@ namespace SBC {
       /*! List of faces on which no fields outflow boundary conditions are to be applied ([xyz][+-]). */
       std::vector<std::string> faceNoFieldsList;
       std::vector<OutflowSpeciesParameters> speciesParams;
+      
+      Real fieldBoundaryCopyFromExistingFaceNbrMagneticField(
+         const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
+         const CellID& cellID,
+         cuint& component
+      );
+      /*! Factor by which to quench the inflowing parts of the velocity distribution function.*/
+      Real quenchFactor;
       
       enum vlasovscheme {
          NONE,

--- a/sysboundary/outflow.h
+++ b/sysboundary/outflow.h
@@ -135,17 +135,14 @@ namespace SBC {
       bool facesToProcess[6];
       /*! Array of bool telling which faces are going to be processed by the fields system boundary condition.*/
       bool facesToSkipFields[6];
+      /*! Array of bool telling which faces are going to be reapplied upon restart.*/
+      bool facesToReapply[6];
       /*! List of faces on which outflow boundary conditions are to be applied ([xyz][+-]). */
       std::vector<std::string> faceList;
       /*! List of faces on which no fields outflow boundary conditions are to be applied ([xyz][+-]). */
       std::vector<std::string> faceNoFieldsList;
       std::vector<OutflowSpeciesParameters> speciesParams;
       
-      Real fieldBoundaryCopyFromExistingFaceNbrMagneticField(
-         const dccrg::Dccrg<SpatialCell,dccrg::Cartesian_Geometry>& mpiGrid,
-         const CellID& cellID,
-         cuint& component
-      );
       /*! Factor by which to quench the inflowing parts of the velocity distribution function.*/
       Real quenchFactor;
       

--- a/testpackage/tests/Flowthrough_trans_periodic/Flowthrough_trans_periodic.cfg
+++ b/testpackage/tests/Flowthrough_trans_periodic/Flowthrough_trans_periodic.cfg
@@ -70,14 +70,16 @@ boundary = Maxwellian
 
 [Flowthrough]
 emptyBox = 0
-T = 100000.0
-rho  = 1000000.0
 Bx = 1.0e-9
 By = 1.0e-9
 Bz = 1.0e-9
+densityModel = SheetMaxwellian
+
+[proton_Flowthrough]
+T = 100000.0
+rho  = 1000000.0
 VX0 = 4e5
 VY0 = 4e5
 VZ0 = 4e5
 nSpaceSamples = 2
 nVelocitySamples = 2
-densityModel = SheetMaxwellian

--- a/testpackage/tests/Flowthrough_x_inflow_y_outflow/Flowthrough_x_inflow_y_outflow.cfg
+++ b/testpackage/tests/Flowthrough_x_inflow_y_outflow/Flowthrough_x_inflow_y_outflow.cfg
@@ -70,28 +70,40 @@ boundary = Outflow
 boundary = Maxwellian
 
 [outflow]
+precedence = 3
+
+[proton_outflow]
+reapplyFaceUponRestart = x+
+reapplyFaceUponRestart = y+
+vlasovScheme_face_x+ = Copy
+vlasovScheme_face_y+ = Copy
 face = x+
 face = y+
 precedence = 3
 
 [maxwellian]
-dynamic = 0
 face = x-
 face = y-
+dynamic = 0
+precedence = 2
+
+[proton_maxwellian]
 file_x- = sw1.dat
 file_y- = sw1.dat
-precedence = 2
 
 [Flowthrough]
 emptyBox = 1
-T = 100000.0
-rho  = 1000000.0
 Bx = 1.0e-9
 By = 1.0e-9
 Bz = 1.0e-9
+densityModel = Maxwellian
+
+[proton_Flowthrough]
+T = 100000.0
+rho  = 1000000.0
 VX0 = 4e5
 VY0 = 0
 VZ0 = 0
 nSpaceSamples = 2
 nVelocitySamples = 2
-densityModel = Maxwellian
+

--- a/testpackage/tests/Flowthrough_x_inflow_y_outflow_acc/Flowthrough_x_inflow_y_outflow_acc.cfg
+++ b/testpackage/tests/Flowthrough_x_inflow_y_outflow_acc/Flowthrough_x_inflow_y_outflow_acc.cfg
@@ -70,28 +70,38 @@ boundary = Outflow
 boundary = Maxwellian
 
 [outflow]
-face = x+
-face = y+
 precedence = 3
 
+[proton_outflow]
+reapplyFaceUponRestart = x+
+reapplyFaceUponRestart = y+
+vlasovScheme_face_x+ = Copy
+vlasovScheme_face_y+ = None
+face = x+
+face = y+
+
 [maxwellian]
-dynamic = 0
 face = x-
 face = y-
+dynamic = 0
+precedence = 2
+
+[proton_maxwellian]
 file_x- = sw1.dat
 file_y- = sw1.dat
-precedence = 2
 
 [Flowthrough]
 emptyBox = 0
-T = 100000.0
-rho  = 1000000.0
 Bx = 0
 By = 10.0e-9
 Bz = 0
+densityModel = Maxwellian
+
+[proton_Flowthrough]
+T = 100000.0
+rho  = 1000000.0
 VX0 = 4e5
 VY0 = 0
 VZ0 = 0
 nSpaceSamples = 2
 nVelocitySamples = 2
-densityModel = Maxwellian


### PR DESCRIPTION
This allows selecting the boundaries at which outflow cells are to be reset.

Other boundary types have not been touched yet, since this one seemed the most imminent.
As of this moment, it hasn't been tested thoroughly enough yet (feel free to!).