### PR TITLE
Support for growing velocity space at restart time.

### DIFF
--- a/common.h
+++ b/common.h
@@ -64,7 +64,7 @@ void bailout(
 /* Maximum number of blocks in each dimension in velocity space. The
    size of velocity space defined in cfg can at maximum be this large
 */
-#define MAX_BLOCKS_PER_DIM 200
+#define MAX_BLOCKS_PER_DIM 256
 
 
 /*! A namespace for storing indices into an array which contains 

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -465,9 +465,10 @@ bool readBlockData(
          const Real dVx = getObjectWrapper().velocityMeshes[meshID].cellSize[0];
          for(const auto& c : fileVelCoordsX) {
             Real cellindex = (c - getObjectWrapper().velocityMeshes[meshID].meshMinLimits[0]) / dVx;
-            if(nearbyint(cellindex) != cellindex) {
+            if(fabs(nearbyint(cellindex) - cellindex) > 1./10000.) {
                logFile << "(RESTART) ERROR: Can't resize velocity space as cell coordinates don't match." << endl
-                  << "(X coordinate " << c << " = " << cellindex <<" * " << dVx << " (dV))" << endl << write;
+                  << "          (X coordinate " << c << " = " << cellindex <<" * " << dVx << " + " << getObjectWrapper().velocityMeshes[meshID].meshMinLimits[0] << endl
+                  << "           coordinate  = cellindex *   dV  +  meshMinLimits)" << endl << write;
                abort();
             }
          }
@@ -475,9 +476,10 @@ bool readBlockData(
          const Real dVy = getObjectWrapper().velocityMeshes[meshID].cellSize[1];
          for(const auto& c : fileVelCoordsY) {
             Real cellindex = (c - getObjectWrapper().velocityMeshes[meshID].meshMinLimits[1]) / dVy;
-            if(nearbyint(cellindex) != cellindex) {
+            if(fabs(nearbyint(cellindex) - cellindex) > 1./10000.) {
                logFile << "(RESTART) ERROR: Can't resize velocity space as cell coordinates don't match." << endl
-                  << "(Y coordinate " << c << " = " << cellindex <<" * " << dVy << " (dV))" << endl << write;
+                  << "           (Y coordinate " << c << " = " << cellindex <<" * " << dVy << " + " << getObjectWrapper().velocityMeshes[meshID].meshMinLimits[1] << endl
+                  << "           coordinate  = cellindex *   dV  +  meshMinLimits)" << endl << write;
                abort();
             }
          }
@@ -485,9 +487,10 @@ bool readBlockData(
          const Real dVz = getObjectWrapper().velocityMeshes[meshID].cellSize[2];
          for(const auto& c : fileVelCoordsY) {
             Real cellindex = (c - getObjectWrapper().velocityMeshes[meshID].meshMinLimits[2]) / dVz;
-            if(nearbyint(cellindex) != cellindex) {
+            if(fabs(nearbyint(cellindex) - cellindex) > 1./10000.) {
                logFile << "(RESTART) ERROR: Can't resize velocity space as cell coordinates don't match." << endl
-                  << "(Z coordinate " << c << " = " << cellindex <<" * " << dVz << " (dV))" << endl << write;
+                  << "           (Z coordinate " << c << " = " << cellindex <<" * " << dVz << " + " << getObjectWrapper().velocityMeshes[meshID].meshMinLimits[2] << endl
+                  << "           coordinate  = cellindex *   dV  +  meshMinLimits)" << endl << write;
                abort();
             }
          }

--- a/ioread.cpp
+++ b/ioread.cpp
@@ -436,7 +436,8 @@ bool readBlockData(
          if(ourMeshParams.gridLength[0] < fileMeshBBox[0] ||
                ourMeshParams.gridLength[1] < fileMeshBBox[1] ||
                ourMeshParams.gridLength[2] < fileMeshBBox[2]) {
-            logFile << "(RESTART) WARNING: trying to shrink velocity space has undefined behaviour if velocity cells outside of the new extents are encountered." << endl << write;
+            logFile << "(RESTART) ERROR: trying to shrink velocity space." << endl << write;
+            abort();
          }
 
          // If we are mismatched, we have to iterate through the velocity coords to see if we have a


### PR DESCRIPTION
This only works if the new velocity grids coordinates match up with the
old one perfectly, and it just adds additional cells around the outside.

Tested:
 - [X] Restarting with a non-fitting velocity space gives an error message and dies
 - [X] Restarting with an unchanged velocity space continues to work
 - [x] Restarting with a properly resized velocity space works