### PR TITLE
Corrected testpackage handling of CXXFLAGS and ordering for PAPI and …

### DIFF
--- a/MAKE/Makefile.Freezer
+++ b/MAKE/Makefile.Freezer
@@ -24,31 +24,6 @@ else
 	INC_VECTORCLASS = -I$(LIBRARY_PREFIX)/../vlasiator/vlasovsolver
 endif
 
-#======== PAPI ==========
-#Add PAPI_MEM define to use papi to report memory consumption?
-#CXXFLAGS +=  -DPAPI_MEM
-
-
-#======== Allocator =========
-#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
-#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
-#CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
-
-
-#======= Compiler and compilation flags =========
-# NOTES on compiler flags:
-# CXXFLAGS is for compiler flags, they are always used
-# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
-# LDFLAGS flags for linker
-
-#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
-#                    avoid memleak (much slower IO)
-#-DMPICH_IGNORE_CXX_SEEK: Ignores some multiple definition 
-#                         errors that come up when using 
-#                         mpi.h in c++ on Cray
-
-#CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
-
 #FLAGS = -ggdb
 
 #GNU flags:
@@ -64,6 +39,25 @@ testpackage: MATHFLAGS =  -fno-unsafe-math-optimizations
 LDFLAGS =
 #-g -ggdb
 LIB_MPI = -lgomp -lgfortran -lpapi
+
+
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+#CXXFLAGS += -DPAPI_MEM
+#testpackage: CXXFLAGS += -DPAPI_MEM
+
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+#CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+#testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
 
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson

--- a/MAKE/Makefile.docker
+++ b/MAKE/Makefile.docker
@@ -18,15 +18,27 @@ else
 	VECTORCLASS = VEC4D_AGNER
 endif
 
+FLAGS = 
+
+#GNU flags:
+CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -fabi-version=0 -mavx2
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17 -fabi-version=0  -mavx
+
+MATHFLAGS = -ffast-math
+LDFLAGS = -g
+LIB_MPI = -lgomp
+
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #======= Compiler and compilation flags =========
@@ -42,16 +54,7 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         mpi.h in c++ on Cray
 
 CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
-
-FLAGS = 
-
-#GNU flags:
-CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++11 -W -Wall -Wno-unused -fabi-version=0 -mavx2
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++0x -fabi-version=0  -mavx
-
-MATHFLAGS = -ffast-math
-LDFLAGS = -g
-LIB_MPI = -lgomp
+testpackage: CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
 
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson

--- a/MAKE/Makefile.hawk_gcc_mpt
+++ b/MAKE/Makefile.hawk_gcc_mpt
@@ -66,12 +66,13 @@ LIBRARY_PREFIX = /zhome/academic/HLRS/pri/ipryakem/libraries
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
-
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #compiled libraries

--- a/MAKE/Makefile.hawk_gcc_openmpi
+++ b/MAKE/Makefile.hawk_gcc_openmpi
@@ -49,12 +49,14 @@ LIBRARY_PREFIX = /zhome/academic/HLRS/pri/ipryakem/libraries
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #compiled libraries

--- a/MAKE/Makefile.hawk_intel_mpt
+++ b/MAKE/Makefile.hawk_intel_mpt
@@ -26,6 +26,7 @@ FLAGS =
 #GNU flags:
 CC_BRAND = intel
 CC_BRAND_VERSION = 19.1.0
+# note: std was not updated to c++17
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++14 -W -Wall -Wno-unused -march=core-avx2 -qopt-zmm-usage=high
 testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
@@ -47,12 +48,14 @@ LIBRARY_PREFIX = /zhome/academic/HLRS/pri/ipryakem/libraries
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #compiled libraries

--- a/MAKE/Makefile.hawk_intel_openmpi
+++ b/MAKE/Makefile.hawk_intel_openmpi
@@ -26,6 +26,7 @@ FLAGS =
 #GNU flags:
 CC_BRAND = intel
 CC_BRAND_VERSION = 19.1.0
+#note: std was not updated to c++17
 CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++14 -W -Wall -Wno-unused -march=core-avx2 -qopt-zmm-usage=high
 testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++14 -W -Wno-unused -march=core-avx2
 not_parallel_tools: CXXFLAGS += -march=native -mno-avx2 -mavx 
@@ -49,12 +50,14 @@ LIBRARY_PREFIX = /zhome/academic/HLRS/pri/ipryakem/libraries
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #compiled libraries

--- a/MAKE/Makefile.home
+++ b/MAKE/Makefile.home
@@ -2,8 +2,10 @@ CMP = mpic++
 LNK = mpic++
 
 FLAGS =
-CXXFLAGS = -I$(HOME)/include -I/usr/include -L$(HOME)/lib -L/usr/lib -O3 -funroll-loops -std=c++11 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp
-#CXXFLAGS = -I$(HOME)/include -L$(HOME)/lib -O0 -funroll-loops -std=c++11 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces -g -fopenmp
+# note: std was c++11
+# note: testpackage settings missing
+CXXFLAGS = -I$(HOME)/include -I/usr/include -L$(HOME)/lib -L/usr/lib -O3 -funroll-loops -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces  -fopenmp
+#CXXFLAGS = -I$(HOME)/include -L$(HOME)/lib -O0 -funroll-loops -std=c++17 -W -Wall -pedantic -Wno-unused -Wno-unused-parameter -Wno-missing-braces -g -fopenmp
 MATHFLAGS = -ffast-math
 LDFLAGS = -L $(HOME)/lib
 LIB_MPI = -lgomp

--- a/MAKE/Makefile.kstppd
+++ b/MAKE/Makefile.kstppd
@@ -9,43 +9,31 @@
 
 ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
 #Single-precision
-	VECTORCLASS = VEC4F_FALLBACK
-else
-#Double-precision
-	VECTORCLASS = VEC4D_FALLBACK
-endif
-
-
-#======== Allocator =========
-#Use TBB malloc
-
-CMP = mpic++
-LNK = mpic++
-
-PAPI_FLAG =
-
-#======== Vectorization ==========
-#Set vector backend type for vlasov solvers, sets precision and length.
-#NOTE this has to have the same precision as the distribution function define (DISTRIBUTION_FP_PRECISION)
-#Options:
-# AVX:	    VEC4D_AGNER, VEC4F_AGNER, VEC8F_AGNER
-# AVX512:   VEC8D_AGNER, VEC16F_AGNER
-# Fallback: VEC4D_FALLBACK, VEC4F_FALLBACK, VEC8F_FALLBACK
-
-ifeq ($(DISTRIBUTION_FP_PRECISION),SPF)
-#Single-precision
 	VECTORCLASS = VEC8F_AGNER
 else
 #Double-precision
 	VECTORCLASS = VEC4D_AGNER
 endif
 
+CMP = mpic++
+LNK = mpic++
+
 FLAGS =
-#CXXFLAGS = -I $(HOME)/include  -L $(HOME)/lib -g  -funroll-loops -std=c++0x -fopenmp -W -Wall -pedantic -Wno-unused -fabi-version=0 -mavx
-CXXFLAGS = -I $(HOME)/include  -L $(HOME)/lib -O3  -funroll-loops -std=c++0x -fopenmp -W -Wall -Wno-unused -fabi-version=0 -mavx
+
+#note: std was c++0x
+#note: no testpackage flags
+#CXXFLAGS = -I $(HOME)/include  -L $(HOME)/lib -g  -funroll-loops -std=c++17 -fopenmp -W -Wall -pedantic -Wno-unused -fabi-version=0 -mavx
+CXXFLAGS = -I $(HOME)/include  -L $(HOME)/lib -O3  -funroll-loops -std=c++17 -fopenmp -W -Wall -Wno-unused -fabi-version=0 -mavx
 MATHFLAGS = -ffast-math
 LDFLAGS = -L $(HOME)/lib
 LIB_MPI = -lgomp
+
+
+#======== Allocator =========
+#Use TBB malloc
+
+
+PAPI_FLAG =
 
 
 #======== Libraries ===========

--- a/MAKE/Makefile.mahti_gcc
+++ b/MAKE/Makefile.mahti_gcc
@@ -4,7 +4,6 @@ LNK = mpic++
 # Modules loaded
 # module load gcc boost jemalloc papi openmpi zoltan
 
-
 #======== Vectorization ==========
 #Set vector backend type for vlasov solvers, sets precision and length. 
 #Options: 
@@ -20,16 +19,6 @@ else
 	VECTORCLASS = VEC4D_AGNER
 endif
 
-
-#======= Compiler and compilation flags =========
-# NOTES on compiler flags:
-# CXXFLAGS is for compiler flags, they are always used
-# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
-# LDFLAGS flags for linker
-
-#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
-#                    avoid memleak (much slower IO)
-
 FLAGS = 
 
 #GNU flags:
@@ -42,6 +31,26 @@ MATHFLAGS = -ffast-math
 LDFLAGS = -lrt
 LIB_MPI = -lgomp 
 
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
+
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
+
+#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
+#                    avoid memleak (much slower IO)
+
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson
 #
@@ -50,16 +59,6 @@ LIB_MPI = -lgomp
 MPT_VERSION = 4.0.3
 JEMALLOC_VERSION = 5.2.1
 LIBRARY_PREFIX = /users/kempf/libraries
-
-#======== PAPI ==========
-#Add PAPI_MEM define to use papi to report memory consumption?
-CXXFLAGS +=  -DPAPI_MEM
-
-
-#======== Allocator =========
-#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
-#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
-CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #compiled libraries

--- a/MAKE/Makefile.marconi
+++ b/MAKE/Makefile.marconi
@@ -25,15 +25,28 @@ else
 	VECTORCLASS = VEC8D_AGNER
 endif
 
+#GNU flags:
+CC_BRAND = intel
+CC_BRAND_VERSION = 17.0.1
+# note: std was c++11
+CXXFLAGS +=  -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias
+testpackage: CXXFLAGS = -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++17 -qopenmp -ansi-alias
+MATHFLAGS = 
+LDFLAGS += -qopenmp -lifcore -Wl,-rpath,/cineca/prod/opt/libraries/boost/1.61.0/intelmpi--2017--binary/lib,-rpath,/marconi_work/Pra14_3521/libraries/phiprof/lib,-rpath,/marconi_work/Pra14_3521/libraries/papi/lib
+CMP = mpicxx
+LNK = mpicxx
+
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 
 #======== Allocator =========
 #Use TBB malloc
 #LDFLAGS += -L$(TBBROOT)/lib/intel64/gcc4.7/ -ltbbmalloc_proxy -ltbbmalloc
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #======= Compiler and compilation flags =========
@@ -41,16 +54,6 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 # CXXFLAGS is for compiler flags, they are always used
 # MATHFLAGS are for special math etc. flags, these are only applied on solver functions
 # LDFLAGS flags for linker
-#GNU flags:
-CC_BRAND = intel
-CC_BRAND_VERSION = 17.0.1
-CXXFLAGS +=  -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++11 -qopenmp -ansi-alias
-testpackage: CXXFLAGS = -O2 -g -DMAX_VECTOR_SIZE=512 -xMIC-AVX512 -std=c++11 -qopenmp -ansi-alias
-MATHFLAGS = 
-LDFLAGS += -qopenmp -lifcore -Wl,-rpath,/cineca/prod/opt/libraries/boost/1.61.0/intelmpi--2017--binary/lib,-rpath,/marconi_work/Pra14_3521/libraries/phiprof/lib,-rpath,/marconi_work/Pra14_3521/libraries/papi/lib
-CMP = mpicxx
-LNK = mpicxx
-
 
 #======== Libraries ===========
 

--- a/MAKE/Makefile.puhti_gcc
+++ b/MAKE/Makefile.puhti_gcc
@@ -16,16 +16,6 @@ else
 	VECTORCLASS = VEC8D_AGNER
 endif
 
-
-#======= Compiler and compilation flags =========
-# NOTES on compiler flags:
-# CXXFLAGS is for compiler flags, they are always used
-# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
-# LDFLAGS flags for linker
-
-#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
-#                    avoid memleak (much slower IO)
-
 FLAGS = 
 
 #GNU flags:
@@ -38,6 +28,28 @@ MATHFLAGS = -ffast-math
 LDFLAGS = -lrt
 LIB_MPI = -lgomp 
 
+
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
+#
+#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
+#                    avoid memleak (much slower IO)
+
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+#CXXFLAGS +=  -DPAPI_MEM
+#testpackage: CXXFLAGS +=  -DPAPI_MEM
+
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+
+
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson
 #
@@ -46,17 +58,6 @@ LIB_MPI = -lgomp
 MPT_VERSION = 2.4.0
 JEMALLOC_VERSION = 5.2.1
 LIBRARY_PREFIX = /projappl/project_2000203/libraries
-
-
-#======== PAPI ==========
-#Add PAPI_MEM define to use papi to report memory consumption?
-#CXXFLAGS +=  -DPAPI_MEM
-
-
-#======== Allocator =========
-#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
-#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
-CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #compiled libraries

--- a/MAKE/Makefile.puhti_intel
+++ b/MAKE/Makefile.puhti_intel
@@ -16,16 +16,28 @@ else
 	VECTORCLASS = VEC8D_AGNER
 endif
 
+FLAGS = 
+
+#GNU flags:
+CC_BRAND = intel
+CC_BRAND_VERSION = 19.0.4
+CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++17 -W -Wall -Wno-unused -xHost -ipo -qopt-zmm-usage=high 
+testpackage: CXXFLAGS = -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo
+
+MATHFLAGS = -ffast-math
+LDFLAGS = -qopenmp -lifcore -ipo
+LIB_MPI = 
+
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 #CXXFLAGS +=  -DPAPI_MEM
-
+#testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
-
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:
@@ -40,18 +52,7 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         mpi.h in c++ on Cray
 
 CXXFLAGS += -DMAX_VECTOR_SIZE=512
-
-FLAGS = 
-
-#GNU flags:
-CC_BRAND = intel
-CC_BRAND_VERSION = 19.0.4
-CXXFLAGS += -traceback -g -O3 -qopenmp -std=c++17 -W -Wall -Wno-unused -xHost -ipo -qopt-zmm-usage=high 
-testpackage: CXXFLAGS += -g -traceback -O2 -qopenmp -std=c++17 -W -Wno-unused -xHost -ipo
-
-MATHFLAGS = -ffast-math
-LDFLAGS = -qopenmp -lifcore -ipo
-LIB_MPI = 
+testpackage: CXXFLAGS += -DMAX_VECTOR_SIZE=512
 
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson

--- a/MAKE/Makefile.puhti_pgi
+++ b/MAKE/Makefile.puhti_pgi
@@ -16,15 +16,29 @@ else
 	VECTORCLASS = VEC4D_FALLBACK
 endif
 
+FLAGS = 
+
+#GNU flags:
+CC_BRAND = pgi
+CC_BRAND_VERSION = 19.7
+CXXFLAGS += -g -O3 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
+testpackage: CXXFLAGS = -g -O2 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
+
+MATHFLAGS =
+LDFLAGS = -O3 -acc -g
+LIB_MPI = 
+
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 #CXXFLAGS +=  -DPAPI_MEM
+#testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 #CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+#testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
 
 #======= Compiler and compilation flags =========
@@ -39,17 +53,6 @@ endif
 #                         errors that come up when using 
 #                         mpi.h in c++ on Cray
 
-FLAGS = 
-
-#GNU flags:
-CC_BRAND = pgi
-CC_BRAND_VERSION = 19.7
-CXXFLAGS += -g -O3 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
-testpackage: CXXFLAGS += -g -O2 -acc -D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1 -Minfo=accel
-
-MATHFLAGS =
-LDFLAGS = -O3 -acc -g
-LIB_MPI = 
 
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson

--- a/MAKE/Makefile.vorna_gcc
+++ b/MAKE/Makefile.vorna_gcc
@@ -16,27 +16,13 @@ else
 	VECTORCLASS = VEC4D_AGNER
 endif
 
-#======= Compiler and compilation flags =========
-# NOTES on compiler flags:
-# CXXFLAGS is for compiler flags, they are always used
-# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
-# LDFLAGS flags for linker
-
-#-DNO_WRITE_AT_ALL:  Define to disable write at all to 
-#                    avoid memleak (much slower IO)
-#-DMPICH_IGNORE_CXX_SEEK: Ignores some multiple definition 
-#                         errors that come up when using 
-#                         mpi.h in c++ on Cray
-#
-# CXXFLAGS = -DMPICH_IGNORE_CXX_SEEK
-
 FLAGS = 
 
 #GNU flags:
 CC_BRAND = gcc
 CC_BRAND_VERSION = 8.3.0
 CXXFLAGS += -O3 -fopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx
-testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++0x  -mavx
+testpackage: CXXFLAGS = -O2 -fopenmp -funroll-loops -std=c++17  -mavx
 
 MATHFLAGS = -ffast-math
 LDFLAGS = -lrt -lgfortran -std=c++17
@@ -45,12 +31,19 @@ LIB_MPI = -lgomp
 #======== PAPI ==========
 #Add PAPI_MEM define to use papi to report memory consumption?
 CXXFLAGS +=  -DPAPI_MEM
+testpackage: CXXFLAGS +=  -DPAPI_MEM
 
 #======== Allocator =========
 #Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
 #Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
 CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
+#======= Compiler and compilation flags =========
+# NOTES on compiler flags:
+# CXXFLAGS is for compiler flags, they are always used
+# MATHFLAGS are for special math etc. flags, these are only applied on solver functions
+# LDFLAGS flags for linker
 
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson

--- a/MAKE/Makefile.vorna_intel
+++ b/MAKE/Makefile.vorna_intel
@@ -16,16 +16,17 @@ else
 	VECTORCLASS = VEC4D_AGNER
 endif
 
-#======== PAPI ==========
-#Add PAPI_MEM define to use papi to report memory consumption?
-#CXXFLAGS +=  -DPAPI_MEM
+FLAGS = 
 
+#GNU flags:
+CC_BRAND = gcc
+CC_BRAND_VERSION = 7.3.0
+CXXFLAGS += -g -O3 -qopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx
+testpackage: CXXFLAGS += -g -O2 -qopenmp -funroll-loops -std=c++17  -mavx
 
-#======== Allocator =========
-#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
-#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
-CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
-
+MATHFLAGS = -ffast-math
+LDFLAGS = -lrt -std=c++17 -liomp5
+LIB_MPI = -lgomp
 
 #======= Compiler and compilation flags =========
 # NOTES on compiler flags:
@@ -40,18 +41,19 @@ CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 #                         mpi.h in c++ on Cray
 
 CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
+testpackage: CXXFLAGS += -DMPICH_IGNORE_CXX_SEEK
 
-FLAGS = 
+#======== PAPI ==========
+#Add PAPI_MEM define to use papi to report memory consumption?
+#CXXFLAGS +=  -DPAPI_MEM
+#testpackage: CXXFLAGS +=  -DPAPI_MEM
 
-#GNU flags:
-CC_BRAND = gcc
-CC_BRAND_VERSION = 7.3.0
-CXXFLAGS += -g -O3 -qopenmp -funroll-loops -std=c++17 -W -Wall -Wno-unused -mavx
-testpackage: CXXFLAGS += -g -O2 -qopenmp -funroll-loops -std=c++0x  -mavx
+#======== Allocator =========
+#Use jemalloc instead of system malloc to reduce memory fragmentation? https://github.com/jemalloc/jemalloc
+#Configure jemalloc with  --with-jemalloc-prefix=je_ when installing it
+CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
+testpackage: CXXFLAGS += -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE
 
-MATHFLAGS = -ffast-math
-LDFLAGS = -lrt -std=c++17 -liomp5
-LIB_MPI = -lgomp
 
 # BOOST_VERSION = current trilinos version
 # ZOLTAN_VERSION = current trilinos verson


### PR DESCRIPTION
…jemalloc. Updated most makefiles to std=c++17.

I didn't propagate the INC_VECTORCLASS method seen in Makefile.hawk_gcc_mpt to the other ones, but did some fixes based on what was discovered today about the ordering.