### PR TITLE
Implement tombstones for the custom hashtable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ LIBS += ${LIB_PAPI}
 
 # Define common dependencies
 DEPS_COMMON = common.h common.cpp definitions.h mpiconversion.h logger.h object_wrapper.h
-DEPS_CELL   = spatial_cell.hpp velocity_mesh_old.h velocity_mesh_amr.h velocity_block_container.h
+DEPS_CELL   = spatial_cell.hpp velocity_mesh_old.h velocity_mesh_amr.h velocity_block_container.h open_bucket_hashtable.h
 
 # Define common system boundary condition dependencies
 DEPS_SYSBOUND = ${DEPS_COMMON} ${DEPS_CELL} sysboundary/sysboundarycondition.h sysboundary/sysboundarycondition.cpp

--- a/open_bucket_hashtable.h
+++ b/open_bucket_hashtable.h
@@ -110,9 +110,16 @@ public:
          }
          if (candidate.first == EMPTYBUCKET) {
             // Found an empty bucket, assign and return that.
-            candidate.first = key;
-            fill++;
-            return candidate.second;
+            // (OR: if we encountered a tombstone before, return that)
+            if(firstTombstone != std::numeric_limits<uint32_t>::max()) {
+               buckets[(hashIndex + firstTombstone) & bitMask] .first = key;
+               fill++;
+               return buckets[(hashIndex + firstTombstone) & bitMask].second;
+            } else {
+               candidate.first = key;
+               fill++;
+               return candidate.second;
+            }
          }
       }
 

--- a/velocity_mesh_old.h
+++ b/velocity_mesh_old.h
@@ -102,6 +102,7 @@ namespace vmesh {
       size_t size() const;
       size_t sizeInBytes() const;
       void swap(VelocityMesh& vm);
+      void scrub();
 
     private:
       static std::vector<vmesh::MeshParameters> meshParameters;
@@ -671,6 +672,11 @@ namespace vmesh {
    void VelocityMesh<GID,LID>::swap(VelocityMesh& vm) {
       globalToLocalMap.swap(vm.globalToLocalMap);
       localToGlobalMap.swap(vm.localToGlobalMap);
+   }
+
+   template<typename GID,typename LID> inline
+   void VelocityMesh<GID,LID>::scrub() {
+      globalToLocalMap.scrub();
    }
    
 } // namespace vmesh


### PR DESCRIPTION
This speeds up the pathological cases (namely, acctest_2) significantly.

Will be interesting to see how it compares to the tombstone-less implementation.